### PR TITLE
ThrottlingActor should send ReleaseThrottle to self

### DIFF
--- a/src/main/scala/com/sksamuel/akka/patterns/DiscardingThrottlingActor.scala
+++ b/src/main/scala/com/sksamuel/akka/patterns/DiscardingThrottlingActor.scala
@@ -30,7 +30,7 @@ class ThrottlingActor(duration: FiniteDuration, target: ActorRef) extends Actor 
           target ! msg
           throttled = true
           context.system.scheduler.scheduleOnce(duration) {
-            target ! ReleaseThrottle
+            self ! ReleaseThrottle
           }
       }
   }


### PR DESCRIPTION
Feel like ReleaseThrottle should be sent back to the throttling actor, not the target actor. I may be misunderstanding - is the intention genuinely to send ReleaseThrottle to the target so that it can send it back?